### PR TITLE
Upgrade to React 17

### DIFF
--- a/site/.eslintrc
+++ b/site/.eslintrc
@@ -22,5 +22,9 @@
     "es6": true,
     "node": true
   },
-  "rules": { "react/jsx-uses-react": "error", "react/jsx-uses-vars": "error" }
+  "rules": {
+    "react/jsx-uses-vars": "error",
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off"
+  }
 }

--- a/site/gatsby-browser.js
+++ b/site/gatsby-browser.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { defaultTheme, ThemeProvider } from 'evergreen-ui'
 

--- a/site/package.json
+++ b/site/package.json
@@ -27,8 +27,8 @@
     "gatsby-transformer-yaml": "^2.4.10",
     "prismjs": "^1.21.0",
     "prop-types": "^15.7.2",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "17.0.0",
+    "react-dom": "17.0.0",
     "react-feather": "^2.0.8",
     "react-helmet": "^6.1.0"
   },

--- a/site/src/components/author.js
+++ b/site/src/components/author.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { graphql, useStaticQuery } from 'gatsby'
 import GatsbyImage from 'gatsby-image'

--- a/site/src/components/layout.js
+++ b/site/src/components/layout.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { graphql, useStaticQuery, Link as GatsbyLink } from 'gatsby'
 import SEO from '../components/seo'
@@ -9,7 +8,7 @@ function Layout({ pageSEO = {}, children }) {
   const { author, social, navLinks } = data.site.siteMetadata
 
   return (
-    <React.Fragment>
+    <>
       <SEO {...pageSEO} />
       <header>
         <nav>
@@ -26,7 +25,7 @@ function Layout({ pageSEO = {}, children }) {
         {` `}
         <Link href={social.github}>Github</Link>
       </footer>
-    </React.Fragment>
+    </>
   )
 }
 

--- a/site/src/components/seo.js
+++ b/site/src/components/seo.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 import { useStaticQuery, graphql } from 'gatsby'

--- a/site/src/pages/404.js
+++ b/site/src/pages/404.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Layout from '../components/layout'
 
 function NotFoundPage() {

--- a/site/src/pages/about.js
+++ b/site/src/pages/about.js
@@ -1,6 +1,4 @@
-import React from 'react'
-// import { graphql } from 'gatsby'
-import Layout from '../components/layout'
+import Layout from '../components/layout';
 
 function AboutPage() {
   // const authorImages = data.

--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { Link as GatsbyLink, graphql } from 'gatsby'
 import Layout from '../components/layout'

--- a/site/src/templates/blog-post.js
+++ b/site/src/templates/blog-post.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import { Link as GatsbyLink, graphql } from 'gatsby'
 import { MDXRenderer } from 'gatsby-plugin-mdx'

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -12826,15 +12826,14 @@ react-dev-utils@^4.2.3:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+react-dom@17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.0.tgz#f8266e4d9861584553ccbd186d596a1c7dd8dcb4"
+  integrity sha512-OGnFbxCjI2TMAZYMVxi4hqheJiN8rCEVVrL7XIGzCB6beNc4Am8M47HtkvxODZw9QgjmAPKpLba9FTu4fC1byA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.0"
 
 react-error-overlay@^3.0.0:
   version "3.0.0"
@@ -13006,7 +13005,15 @@ react-transition-group@^4.4.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^16.13.1, react@^16.8.0:
+react@17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.0.tgz#ad96d5fa1a33bb9b06d0cc52672f7992d84aa662"
+  integrity sha512-rG9bqS3LMuetoSUKHN8G3fMNuQOePKDThK6+2yXFWtoeTDLVNh/QCaxT+Jr+rNf4lwNXpx+atdn3Aa0oi8/6eQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+react@^16.8.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
@@ -13820,6 +13827,14 @@ scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.20.0:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
+  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
- Update react and react-dom to v17
- Turn off unnecessary eslint rules
- Remove unused react imports [with script](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports)